### PR TITLE
update clap to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ binwrite = "0.2.1"
 serde = { version = "1", features = ["derive"], optional = true }
 
 # cli
-clap = { version = "3.0.0-beta", optional = true }
+clap = { version = "3.2.17", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8", optional = true }
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use std::fs;
 
 use lvd::LvdFile;
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Args {
     in_file: PathBuf,
     out_file: Option<PathBuf>,


### PR DESCRIPTION
The crate wasn't compiling for me using the beta branch. This PR updates clap and fixes the errors.